### PR TITLE
Fix core\db\plugin_checks_test::test_db_install_file

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -26,9 +26,9 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="questionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key link to question.id."/>
-        <FIELD NAME="questiontext" TYPE="text" LENGTH="medium"  NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="questiontext" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="questiontextformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="answertext" TYPE="text" LENGTH="medium" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="answertext" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="answertextformat" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>


### PR DESCRIPTION
Hello,
the core test core\db\plugin_checks_test::test_db_install_file fails since LENGTH="medium" is ignored for type="text" so the comparison throws an error, because the table is created without it. Please integrate, thank you.
Best Regards